### PR TITLE
[rym-lpath] Add support for single wildcard match in path

### DIFF
--- a/rym-lpath/rym/lpath/_get.py
+++ b/rym-lpath/rym/lpath/_get.py
@@ -23,6 +23,15 @@ Or, specify multiple options and get the first match
 >>> lpath.get(example, ['hello.world', '0.a.1'])
 'y'
 
+Wildcards can be used to access any element. A trailing asterisk will always
+return the final value as is; in all other cases, the return value will be
+a list of items.
+
+>>> lpath.get(example, '*.*.bar')
+[['baz']]
+>>> lpath.get(example, '*.*.*')
+[[['x', 'y', 'z'], 42], [{'bar': 'baz'}]]
+
 """
 
 import logging
@@ -50,6 +59,12 @@ def get(
 ) -> Any:
     """Return the value of the property found at the given key.
 
+    Wildcards:
+        A single asterisk may be used as a wildcard to match any value.
+        A trailing asterisk will return the final value as is; i.e., it doesn't
+        really do much. When used in any other position, the return value will
+        always be a list of the matched values.
+
     Arguments:
         value: An object, iterable, or mapping
         key: A string indicating the path to the value.
@@ -72,8 +87,14 @@ def get(
         raise
 
 
+# _get
+# ======================================================================
+# This set of dispatchers han
+
+
 @singledispatch
 def _get(key: Any, value: Any, delim: str) -> Any:
+    """Dispatch based a single key or multiple."""
     raise InvalidKey(
         f"invalid key: {key}, ({type(key)}); expected str or list of str"
     )
@@ -104,11 +125,33 @@ def _(key: Iterable[str], value: str, delim: str) -> Any:
     raise KeyError(f"no matches: {key}")
 
 
-@singledispatch
+# _get_from
+# ======================================================================
+
+
 def _get_from(value: Any, parts: Deque[str]) -> Any:
+    """Dispatch based on value.
+
+    NOTE: Handles any key-specific logic.
+    NOTE: The type of parts is handled via _get.
+    """
     if not parts:
         return value
     key = parts.popleft()
+    if key == "*":
+        return _get_from_single_asterisk(value, parts)
+    else:
+        return _get_from_dispatch(value, parts, key=key)
+
+
+@singledispatch
+def _get_from_dispatch(value: Any, parts: Deque[str], *, key: str) -> Any:
+    """Dispatch based on the value.
+
+    NOTE: Should ONLY be called via _get_from. All key-specific logic is
+        processed in that function.
+    NOTE: Assume value is an object.
+    """
     try:
         curr = getattr(value, key)
     except AttributeError as err:
@@ -116,24 +159,93 @@ def _get_from(value: Any, parts: Deque[str]) -> Any:
     return _get_from(curr, parts)
 
 
-@_get_from.register(abc.Iterable)
-def _(value: Iterable, parts: Deque[str]) -> Any:
-    if not parts:
-        return value
-    key = int(parts.popleft())
+@_get_from_dispatch.register(abc.Mapping)
+def _(value: Mapping, parts: Deque[str], *, key: str) -> Any:
+    return _get_from(value[key], parts)
+
+
+@_get_from_dispatch.register(abc.Iterable)
+def _(value: Iterable, parts: Deque[str], *, key: str) -> Any:
+    """Dispatch where value is an iterable (and therefore)"""
     try:
-        curr = value[key]
+        curr = value[int(key)]
     except IndexError:
         raise IndexError(key) from None
     return _get_from(curr, parts)
 
 
-@_get_from.register(abc.Mapping)
-def _(value: Mapping, parts: Deque[str]) -> Any:
+# _get_from_single_asterisk
+# ======================================================================
+
+
+def _get_from_single_asterisk(value: Any, parts: Deque[str]) -> Any:
+    # NOTE: The asterisk has already been removed from "parts"
     if not parts:
+        # NOTE: Return value as is if the asterisk was the last item.
         return value
-    key = parts.popleft()
-    return _get_from(value[key], parts)
+    elif not value:
+        # Edge case. We have parts, but no ability to go deeper.
+        # NOTE: Stick to ValueError -- we don't know what was expected.
+        partial_key = ".".join(parts)
+        raise ValueError(f"failure to match after asterisk: *.{partial_key}")
+    return list(_yield_from_single_asterisk(value, parts))
+
+
+def _yield_from_single_asterisk(
+    value: Mapping,
+    parts: Deque[str],
+) -> abc.Generator[Any, None, None]:
+    itr = _get_iter(value)  # may raise
+    errors = []
+    matched_any = False
+    for item in itr:
+        try:
+            yield _get_from(item, parts.copy())
+        except (
+            AttributeError,
+            IndexError,
+            KeyError,
+            ValueError,
+            TypeError,
+        ) as err:
+            # TODO: Use an exception group
+            tb = TracebackException.from_exception(err)
+            errors.append(tb)
+        else:
+            matched_any = True
+
+    if errors and not matched_any:
+        # NOTE: Stick to ValueError -- we don't know what was expected.
+        partial_key = ".".join(parts)
+        raise ValueError(f"failure to match after asterisk: *.{partial_key}")
+
+
+# _get_iter
+# ======================================================================
+# Standardize iterable for asterisk feature
+
+
+@singledispatch
+def _get_iter(value: Any) -> Iterable:
+    # NOTE: because we support object introspection, don't reject this
+    return vars(value).values()  # may raise later
+
+
+@_get_iter.register(str)
+def _get_iter_err(value: Any) -> Iterable:
+    raise TypeError("iterable or object with __dict__ expected for asterisk part")
+
+
+@_get_iter.register(abc.Mapping)
+def _(value: Mapping) -> Iterable:
+    # NOTE: This ignores the keys, which probably isn't ideal. However, it's a
+    #   reasonable concession to make for wild card matching.
+    return value.values()
+
+
+@_get_iter.register(abc.Iterable)
+def _(value: Iterable) -> Iterable:
+    return value
 
 
 # __END__


### PR DESCRIPTION
- [x] Add support for wildcard in path, e.g, 'a.*.b'.